### PR TITLE
Make curves handle claims

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "cw-controllers"
-version = "0.8.0-rc2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da0838f230f3b6b75d19619019815ccfb18bf333cd477350431ae6c6eab221c"
+checksum = "ff50deaba22e0a37d6542ef4e4141e2cbe8f63dd9de23655762841f38517542e"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
@@ -159,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.8.0-rc2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb8e7cab1cecec97fdc913fc8a24b090f4ece590a38e0b8a8d3ae4b008e8fdd"
+checksum = "c1e867b9972b83b32e00e878dfbff48299ba26618dabeb19b9c56fae176dc225"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "cw0"
-version = "0.8.0-rc2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f822a0780c6440604d66b416a42d726f9180ef9717e302a177b65d389d272d"
+checksum = "c497f885a40918a02df7d938c81809965fa05cfc21b3dc591e9950237b5de0a9"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "0.8.0-rc2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef3cf7bd05f56a9b4281c764f8d6347fe9f60b017ef3c7a3900d552684a87d89"
+checksum = "4d48454f96494aa1018556cd457977375cc8c57ef3e5c767cfa2ea5ec24b0258"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "cw20"
-version = "0.8.0-rc2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f51a166ddfda481ae837621c72d1bea749685661a966cab775fd65468cb2cb"
+checksum = "a11a2adbd52258f5b4ed5323f62bc6e559f2cefbe52ef0e58290016fde5bb083"
 dependencies = [
  "cosmwasm-std",
  "cw0",
@@ -206,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "cw20-base"
-version = "0.8.0-rc2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57ffaf45a901b71c8654431eaa6167a7b492c9aafc569bfdb2799c24a4f72f"
+checksum = "fe3791e0f6b4a0a82b86541d48dcc67c2d607da8e5691a91b40b2c06ddf09c52"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "cw20-bonding"
-version = "0.8.0-rc2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84a2b22026f150bb50cfd1f081b875ff1d252b2b8c1603641f01434bcdc2c42"
+checksum = "53ec6f28a129edea87f919fbe31175af640041ca3d66f1483243e06821143de8"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,13 @@ overflow-checks = true
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cw0 = { version = "0.8.0-rc2" }
-cw2 = { version = "0.8.0-rc2" }
-cw20 = { version = "0.8.0-rc2" }
-cw20-base = { version = "0.8.0-rc2", features = ["library"] }
-cw20-bonding = { version = "0.8.0-rc2", features = ["library"] }
-cw-controllers = { version = "0.8.0-rc2" }
-cw-storage-plus = { version = "0.8.0-rc2" }
+cw0 = { version = "0.8.1" }
+cw2 = { version = "0.8.1" }
+cw20 = { version = "0.8.1" }
+cw20-base = { version = "0.8.1", features = ["library"] }
+cw20-bonding = { version = "0.8.1", features = ["library"] }
+cw-controllers = { version = "0.8.1" }
+cw-storage-plus = { version = "0.8.1" }
 cosmwasm-std = { version = "0.16.0-rc5", default-features = false, features = ["staking"] }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # CW-20 Bondcamp
 
-Excuse the name. More docs coming soon. Issue and buy tokens based on a `Work` by and `Artist` that has a permalink URI.
+Excuse the name. More docs coming soon. Issue and buy tokens based on a `Work` by and `Creator` that has a permalink URI.
 
 It is up to the initial artist or curator to supply a stable permalink and image. It may be that this is a link to a page that has an aggregation of different resources for the `Work`.
 
@@ -18,6 +18,8 @@ For example, for a release, you might want a page that aggregates:
 This is intended to be used for discovery, rather than media playback, hence why Wikipedia is potentially a valid reference. Until recently, Tool and MBV weren't on Spotify or online services, but you might want to curate their work.
 
 Alternatively, an artist themselves might want to instantiate one contract _per_ service. Not 100% why you'd do that, but it's an option.
+
+Equally, this could be used by the curator of a Spotify or YouTube playlist to create tokens and/or stake on that. There's not really any good reason why not.
 
 ## Total supply
 

--- a/schema/instantiate_msg.json
+++ b/schema/instantiate_msg.json
@@ -10,7 +10,6 @@
     "external_permalink_uri",
     "name",
     "reserve_decimals",
-    "reserve_denom",
     "staking_params",
     "symbol",
     "work"
@@ -54,14 +53,10 @@
       "type": "string"
     },
     "reserve_decimals": {
-      "description": "number of decimal places for the reserve token, needed for proper curve math. Same format as decimals above, eg. if it is uatom, where 1 unit is 10^-6 ATOM, use 6 here",
+      "description": "this is the reserve token denom (only support native for now) number of decimal places for the reserve token, needed for proper curve math. Same format as decimals above, eg. if it is uatom, where 1 unit is 10^-6 ATOM, use 6 here",
       "type": "integer",
       "format": "uint8",
       "minimum": 0.0
-    },
-    "reserve_denom": {
-      "description": "this is the reserve token denom (only support native for now)",
-      "type": "string"
     },
     "staking_params": {
       "description": "put all the staking params into a basket",

--- a/src/bonding.rs
+++ b/src/bonding.rs
@@ -111,6 +111,8 @@ pub fn execute_buy(
     // calculate how many tokens can be purchased with this and mint them
     let curve = curve_fn(state.decimals);
     state.reserve += payment;
+
+    // curve.supply() calculates native -> CW20
     let new_supply = curve.supply(state.reserve);
     let minted = new_supply
         .checked_sub(state.supply)
@@ -211,6 +213,8 @@ fn do_sell(
         .supply
         .checked_sub(amount)
         .map_err(StdError::overflow)?;
+
+    // curve.reserve() calculates CW20 -> native
     let new_reserve = curve.reserve(state.supply);
     let released = state
         .reserve

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -134,8 +134,8 @@ pub fn do_execute(
         }
 
         // this is the staking logic
-        ExecuteMsg::Bond {} => bond(deps, env, info),
-        ExecuteMsg::Unbond { amount } => unbond(deps, env, info, amount),
+        ExecuteMsg::Bond {} => bond(deps, env, info, curve_fn),
+        ExecuteMsg::Unbond { amount } => unbond(deps, env, info, curve_fn, amount),
         ExecuteMsg::Claim {} => claim(deps, env, info),
         ExecuteMsg::Reinvest {} => reinvest(deps, env, info),
         ExecuteMsg::_BondAllTokens {} => _bond_all_tokens(deps, env, info),

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -54,7 +54,9 @@ pub struct InstantiateMsg {
     pub decimals: u8,
 
     /// this is the reserve token denom (only support native for now)
-    pub reserve_denom: String,
+    // think this probably shouldn't even be settable thanks to staking constraints
+    // which mean staking is native
+    // pub reserve_denom: String,
     /// number of decimal places for the reserve token, needed for proper curve math.
     /// Same format as decimals above, eg. if it is uatom, where 1 unit is 10^-6 ATOM, use 6 here
     pub reserve_decimals: u8,

--- a/src/query.rs
+++ b/src/query.rs
@@ -20,9 +20,9 @@ pub struct TokenInfoResponseWithMeta {
 pub struct InvestmentResponse {
     pub token_supply: Uint128,
     pub staked_tokens: Coin,
-    // ratio of staked_tokens / token_supply (or how many native tokens that one derivative token is nominally worth)
+    // this is covered by curves in our impl
+    // spot price is probably the equivalent
     pub nominal_value: Decimal,
-
     /// owner created the contract and takes a cut
     pub owner: String,
     /// this is how much the owner takes as a cut when someone unbonds


### PR DESCRIPTION
Rather than the default implementation, which uses a straight ratio, this uses the curves to handle staking/unstaking.

Unclear whether buying without staking is even desirable tbh